### PR TITLE
Refactored Code & New Classes

### DIFF
--- a/Source/ConcurAccessToken.swift
+++ b/Source/ConcurAccessToken.swift
@@ -1,0 +1,21 @@
+import SwiftyJSON
+
+public class ConcurAccessToken {
+  
+  public var ExpirationDate: String!
+  public var InstanceUrl: String!
+  public var RefreshToken: String!
+  public var Token: String!
+  
+  public init(json: JSON) {
+    self.ExpirationDate = json["Expiration_date"].string
+    self.InstanceUrl = json["Instance_Url"].string
+    self.RefreshToken = json["Refresh_Token"].string
+    self.Token = json["Token"].string
+  }
+  
+  public init(accessTokenString: String) {
+    self.Token = accessTokenString
+  }
+  
+}

--- a/Source/ConcurClient.swift
+++ b/Source/ConcurClient.swift
@@ -17,6 +17,9 @@ public class ConcurClient {
   
   public init(accessToken: ConcurAccessToken) {
     self.AccessToken = accessToken
+    if let token = accessToken.InstanceUrl {
+      ConcurClient.instanceUrl = token
+    }
   }
   
 }

--- a/Source/ConcurClient.swift
+++ b/Source/ConcurClient.swift
@@ -1,54 +1,22 @@
-import Alamofire
-import SwiftyJSON
-
 public class ConcurClient {
   
-  internal var consumerKey: String!
-  internal var consumerSecret: String!
-  internal var accessToken: String!
+  internal var ConsumerKey: String!
+  internal var ConsumerSecret: String!
+  internal var AccessToken: ConcurAccessToken!
   
   // Initialization with Consumer Key and Consumer Secret
   public init(consumerKey: String, consumerSecret: String) {
-    self.consumerKey = consumerKey
-    self.consumerSecret = consumerSecret
+    self.ConsumerKey = consumerKey
+    self.ConsumerSecret = consumerSecret
   }
   
-  // Initialization with Access Token
+  // Initialization with Access Token string
   public init(accessToken: String) {
-    self.accessToken = accessToken
+    self.AccessToken = ConcurAccessToken(accessTokenString: accessToken)
   }
   
-  // Get Access Token with Native Flow
-  public func getNativeFlowAccessToken(username: String, password: String, callback: (error: String!, expirationDate: String!, instanceUrl: String!, refreshToken: String!, accessToken: String!) -> Void) {
-    if self.consumerKey != nil {
-      // Create authorization header string in the format of LoginID:Password, Base-64 encoded
-      let authorizationString = username.stringByAppendingString(":").stringByAppendingString(password)
-      let authorizationStringUTF = authorizationString.dataUsingEncoding(NSUTF8StringEncoding)
-      let authorizationStringBase64 = authorizationStringUTF?.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.allZeros)
-      let finalAuthorizationString = "Basic ".stringByAppendingString(authorizationStringBase64!)
-      
-      // Send Request and Parse JSON Response
-      var extraHeaders = [
-        "Authorization" : finalAuthorizationString,
-        "X-ConsumerKey" : self.consumerKey!
-      ]
-      let request = Utilities.createHTTPRequest("/net2/oauth2/accesstoken.ashx", headers: Utilities.buildHeaders(extraHeaders), method: "GET", body: nil)
-      Alamofire.request(request).responseJSON { (req, res, json, error) in
-        var jsonObject = JSON(json!)
-        if let error = jsonObject["Error"]["Message"].string {
-          callback(error: error, expirationDate: nil, instanceUrl: nil, refreshToken: nil, accessToken: nil)
-        } else {
-          jsonObject = jsonObject["Access_Token"]
-          callback(error: nil, expirationDate: jsonObject["Expiration_date"].string, instanceUrl: jsonObject["Instance_Url"].string, refreshToken: jsonObject["Refresh_Token"].string, accessToken: jsonObject["Token"].string)
-        }
-      }
-    } else {
-      callback(error: "Consumer Key Needed", expirationDate: nil, instanceUrl: nil, refreshToken: nil, accessToken: nil)
-    }
-  }
-  
-  internal func getAuthString() -> String {
-    return "OAuth ".stringByAppendingString(self.accessToken)
+  public init(accessToken: ConcurAccessToken) {
+    self.AccessToken = accessToken
   }
   
 }

--- a/Source/NativeFlow.swift
+++ b/Source/NativeFlow.swift
@@ -16,7 +16,7 @@ public extension ConcurClient {
           "X-ConsumerKey" : self.ConsumerKey!
         ]
       ]
-      var request = ConcurClient.getHTTPRequest("/net/oauth2/accesstoken.ashx", options: options)
+      var request = ConcurClient.getHTTPRequest("/net2/oauth2/accesstoken.ashx", options: options, authString: nil)
       
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)

--- a/Source/NativeFlow.swift
+++ b/Source/NativeFlow.swift
@@ -1,0 +1,35 @@
+import Alamofire
+import SwiftyJSON
+
+public extension ConcurClient {
+  
+  // Get Access Token with Native Flow
+  public func getNativeFlowAccessToken(username: String, password: String, callback: (error: String!, accessToken: ConcurAccessToken!) -> Void) {
+    if self.ConsumerKey != nil {
+      // Create authorization header string in the format of LoginID:Password, Base-64 encoded
+      let authorizationString = username.stringByAppendingString(":").stringByAppendingString(password)
+      let finalAuthorizationString = "Basic ".stringByAppendingString(ConcurClient.base64Encode(authorizationString))
+      
+      var options: [String : AnyObject?] = [
+        "Headers" : [
+          "Authorization" : finalAuthorizationString,
+          "X-ConsumerKey" : self.ConsumerKey!
+        ]
+      ]
+      var request = ConcurClient.getHTTPRequest("/net/oauth2/accesstoken.ashx", options: options)
+      
+      Alamofire.request(request).responseJSON { (req, res, json, error) in
+        var jsonObject = JSON(json!)
+        if let error = jsonObject["Error"]["Message"].string {
+          callback(error: error, accessToken: nil)
+        } else {
+          jsonObject = jsonObject["Access_Token"]
+          callback(error: nil, accessToken: ConcurAccessToken(json: jsonObject))
+        }
+      }
+    } else {
+      callback(error: "Consumer Key Needed", accessToken: nil)
+    }
+  }
+  
+}

--- a/Source/QuickExpenses.swift
+++ b/Source/QuickExpenses.swift
@@ -72,20 +72,22 @@ public extension ConcurClient {
     }
   }
   
-  public func quickExpensesPost(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
+  public func quickExpensesPost(options: [String : AnyObject?], callback: (error: String!, returnValue: AnyObject!) -> Void) {
     if self.AccessToken != nil {
       let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         let jsonObject = JSON(json!)
         if let error = jsonObject["Error"]["Message"].string {
-          callback(error: error, expense: nil)
+          callback(error: error, returnValue: nil)
+        } else if let error = jsonObject["Message"].string {
+          callback(error: error, returnValue: nil)
         } else {
           var expense = QuickExpense(json: jsonObject)
-          callback(error: nil, expense: expense)
+          callback(error: nil, returnValue: expense)
         }
       }
     } else {
-      callback(error: "Access Token Missing", expense: nil)
+      callback(error: "Access Token Missing", returnValue: nil)
     }
   }
   
@@ -96,6 +98,8 @@ public extension ConcurClient {
         if json != nil {
           let jsonObject = JSON(json!)
           if let error = jsonObject["Error"]["Message"].string {
+            callback(error: error)
+          } else if let error = jsonObject["Message"].string {
             callback(error: error)
           } else {
             callback(error: nil)
@@ -114,6 +118,8 @@ public extension ConcurClient {
         if json != nil {
           let jsonObject = JSON(json!)
           if let error = jsonObject["Error"]["Message"].string {
+            callback(error: error)
+          } else if let error = jsonObject["Message"].string {
             callback(error: error)
           } else {
             callback(error: nil)

--- a/Source/QuickExpenses.swift
+++ b/Source/QuickExpenses.swift
@@ -42,13 +42,9 @@ public class QuickExpense {
 
 public extension ConcurClient {
   
-  public func getAllQuickExpense(parameters: [String : String]!, callback: (error: String!, expenses: [QuickExpense]!, nextPage: String!) -> Void) {
-    if self.accessToken != nil {
-      var extraHeaders = [
-        "Authorization" : self.getAuthString()
-      ]
-      let request = Utilities.createHTTPRequest("/api/v3.0/expense/quickexpenses", headers: Utilities.buildHeaders(extraHeaders), method: "GET", body: nil)
-      Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+  public func getAllQuickExpense(options: [String : AnyObject?], callback: (error: String!, expenses: [QuickExpense]!, nextPage: String!) -> Void) {
+    if self.AccessToken != nil {
+      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
@@ -63,17 +59,13 @@ public extension ConcurClient {
         }
       }
     } else {
-      callback(error: "Access Token Needed", expenses: nil, nextPage: nil)
+      callback(error: "Access Token Missing", expenses: nil, nextPage: nil)
     }
   }
   
-  public func getQuickExpenseById(id: String, parameters: [String : String]!, callback: (error: String!, expense: QuickExpense!) -> Void) {
-    if self.accessToken != nil {
-      var extraHeaders = [
-        "Authorization" : self.getAuthString()
-      ]
-      let request = Utilities.createHTTPRequest("/api/v3.0/expense/quickexpenses/".stringByAppendingString(id), headers: Utilities.buildHeaders(extraHeaders), method: "GET", body: nil)
-      Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+  public func getQuickExpenseById(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
+    if self.AccessToken != nil {
+      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
@@ -84,86 +76,60 @@ public extension ConcurClient {
         }
       }
     } else {
-      callback(error: "Access Token Needed", expense: nil)
+      callback(error: "Access Token Missing", expense: nil)
     }
   }
   
-  public func createQuickExpense(currencyCode: String, transactionAmount: String, transactionDate: String, additionalParameters: [String : String]!, callback: (error: String!, id: String!, uri: String!) -> Void) {
-    if self.accessToken != nil {
-      var extraHeaders = [
-        "Authorization" : self.getAuthString()
-      ]
-      var bodyJSON = NSMutableDictionary()
-      if additionalParameters != nil {
-        for (key, value) in additionalParameters {
-          bodyJSON.setObject(value, forKey: key)
-        }
-      }
-      bodyJSON.setObject(currencyCode, forKey: "CurrencyCode")
-      bodyJSON.setObject(transactionAmount, forKey: "TransactionAmount")
-      bodyJSON.setObject(transactionDate, forKey: "TransactionDate")
-      var error: NSError?
-      var bodyData = NSJSONSerialization.dataWithJSONObject(bodyJSON, options: NSJSONWritingOptions.allZeros, error: &error)
-      let request = Utilities.createHTTPRequest("/api/v3.0/expense/quickexpenses", headers: Utilities.buildHeaders(extraHeaders), method: "POST", body: bodyData)
+  public func createQuickExpense(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
+    if self.AccessToken != nil {
+      let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         let jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
-          callback(error: error, id: nil, uri: nil)
+          callback(error: error, expense: nil)
         } else {
-          callback(error: nil, id: jsonObject["ID"].string, uri: jsonObject["URI"].string)
+          var expense = QuickExpense(json: jsonObject)
+          callback(error: nil, expense: expense)
         }
       }
     } else {
-      callback(error: "Access Token Needed", id: nil, uri: nil)
+      callback(error: "Access Token Missing", expense: nil)
     }
   }
   
-  public func updateQuickExpenseById(id: String, parameters: [String : String], callback: (error: String!) -> Void) {
-    if self.accessToken != nil {
-      var extraHeaders = [
-        "Authorization" : self.getAuthString()
-      ]
-      var bodyJSON = NSMutableDictionary()
-      for (key, value) in parameters {
-        bodyJSON.setObject(value, forKey: key)
-      }
-      var error: NSError?
-      var bodyData = NSJSONSerialization.dataWithJSONObject(bodyJSON, options: NSJSONWritingOptions.allZeros, error: &error)
-      let request = Utilities.createHTTPRequest("/api/v3.0/expense/quickexpenses/".stringByAppendingString(id), headers: Utilities.buildHeaders(extraHeaders), method: "PUT", body: bodyData)
+  public func updateQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
+    if self.AccessToken != nil {
+      let request = ConcurClient.putHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)
           if let error = jsonObject["Message"].string {
             callback(error: error)
+          } else {
+            callback(error: nil)
           }
-        } else {
-          callback(error: nil)
         }
       }
     } else {
-      callback(error: "Access Token Needed")
+      callback(error: "Access Token Missing")
     }
   }
   
-  public func deleteQuickExpenseById(id: String, parameters: [String : String]!, callback: (error: String!) -> Void) {
-    if self.accessToken != nil {
-      var extraHeaders = [
-        "Authorization" : self.getAuthString()
-      ]
-      let request = Utilities.createHTTPRequest("/api/v3.0/expense/quickexpenses/".stringByAppendingString(id), headers: Utilities.buildHeaders(extraHeaders), method: "DELETE", body: nil)
-      Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+  public func deleteQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
+    if self.AccessToken != nil {
+      let request = ConcurClient.deleteHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)
           if let error = jsonObject["Message"].string {
             callback(error: error)
+          } else {
+            callback(error: nil)
           }
-        } else {
-          callback(error: nil)
         }
       }
     } else {
-      callback(error: "Access Token Needed")
+      callback(error: "Access Token Missing")
     }
   }
   

--- a/Source/QuickExpenses.swift
+++ b/Source/QuickExpenses.swift
@@ -2,22 +2,22 @@ import Alamofire
 import SwiftyJSON
 
 public class QuickExpense {
-  public var Comment: String! // A comment that describes the expense. Max Length: 2000
-  public var CurrencyCode: String // The 3-letter ISO 4217 currency code for the expense transaction amount. Example: USD
-  public var ExpenseTypeCode: String! // The code for the expense type in the company's expense management system.
-  public var ExpenseTypeName: String! // The name of the expense type associated with the quick expense.
-  public var ID: String! // The unique identifier of the resource.
-  public var LocationName: String! // The name of the location where the expense was incurred.
-  public var OwnerLoginID: String! // The Concur login ID for the expense owner. Useful for system to system integration when there are expenses for multiple users.
-  public var OwnerName: String! // The first and last name for the expense owner. Useful for system to system integration when there are expenses for multiple users.
-  public var PaymentTypeCode: String! // This element specifies the method of payment for the expense. Format: CASHX = Cash, CPAID = Company Paid, or PENDC = Pending Card Transaction (default)
-  public var ReceiptImageID: String! // The ID of the receipt image associated with this quick expense, if any.
-  public var TransactionAmount: String // The total amount of the expense in the original currency, with up to three decimal places. Example: 123.654
-  public var TransactionDate: String // The date the expense was incurred. Format: YYYY-MM-DD
-  public var URI: String! // The URI to the resource.
-  public var VendorDescription: String! // The descriptive text for the vendor for the quick expense. This often matches the Merchant Name found in a credit card transaction. Max Length: 64
+  private(set) public var Comment: String! // A comment that describes the expense. Max Length: 2000
+  private(set) public var CurrencyCode: String! // The 3-letter ISO 4217 currency code for the expense transaction amount. Example: USD
+  private(set) public var ExpenseTypeCode: String! // The code for the expense type in the company's expense management system.
+  private(set) public var ExpenseTypeName: String! // The name of the expense type associated with the quick expense.
+  private(set) public var ID: String! // The unique identifier of the resource.
+  private(set) public var LocationName: String! // The name of the location where the expense was incurred.
+  private(set) public var OwnerLoginID: String! // The Concur login ID for the expense owner. Useful for system to system integration when there are expenses for multiple users.
+  private(set) public var OwnerName: String! // The first and last name for the expense owner. Useful for system to system integration when there are expenses for multiple users.
+  private(set) public var PaymentTypeCode: String! // This element specifies the method of payment for the expense. Format: CASHX = Cash, CPAID = Company Paid, or PENDC = Pending Card Transaction (default)
+  private(set) public var ReceiptImageID: String! // The ID of the receipt image associated with this quick expense, if any.
+  private(set) public var TransactionAmount: String! // The total amount of the expense in the original currency, with up to three decimal places. Example: 123.654
+  private(set) public var TransactionDate: String! // The date the expense was incurred. Format: YYYY-MM-DD
+  private(set) public var URI: String! // The URI to the resource.
+  private(set) public var VendorDescription: String! // The descriptive text for the vendor for the quick expense. This often matches the Merchant Name found in a credit card transaction. Max Length: 64
   
-  public init(comment: String!, currencyCode: String, expenseTypeCode: String!, expenseTypeName: String!, id: String!, locationName: String!, ownerLoginID: String!, ownerName: String!, paymentTypeCode: String!, receiptImageID: String!, transactionAmount: String, transactionDate: String, uri: String!, vendorDescription: String!) {
+  private init(comment: String!, currencyCode: String!, expenseTypeCode: String!, expenseTypeName: String!, id: String!, locationName: String!, ownerLoginID: String!, ownerName: String!, paymentTypeCode: String!, receiptImageID: String!, transactionAmount: Double!, transactionDate: String!, uri: String!, vendorDescription: String!) {
     self.Comment = comment
     self.CurrencyCode = currencyCode
     self.ExpenseTypeCode = expenseTypeCode
@@ -28,64 +28,56 @@ public class QuickExpense {
     self.OwnerName = ownerName
     self.PaymentTypeCode = paymentTypeCode
     self.ReceiptImageID = receiptImageID
-    self.TransactionAmount = transactionAmount
+    if transactionAmount != nil {
+      self.TransactionAmount = transactionAmount.toString()
+    }
     self.TransactionDate = transactionDate
     self.URI = uri
     self.VendorDescription = vendorDescription
   }
   
-  public convenience init(json: JSON) {
-    self.init(comment: json["Comment"].string, currencyCode: json["CurrencyCode"].string!, expenseTypeCode: json["ExpenseTypeCode"].string, expenseTypeName: json["ExpenseTypeName"].string, id: json["ID"].string, locationName: json["LocationName"].string, ownerLoginID: json["OwnerLoginID"].string, ownerName: json["OwnerName"].string, paymentTypeCode: json["PaymentTypeCode"].string, receiptImageID: json["ReceiptImageID"].string, transactionAmount: json["TransactionAmount"].double!.toString(), transactionDate: json["TransactionDate"].string!, uri: json["URI"].string, vendorDescription: json["VendorDescription"].string)
+  internal convenience init(json: JSON) {
+    self.init(comment: json["Comment"].string, currencyCode: json["CurrencyCode"].string, expenseTypeCode: json["ExpenseTypeCode"].string, expenseTypeName: json["ExpenseTypeName"].string, id: json["ID"].string, locationName: json["LocationName"].string, ownerLoginID: json["OwnerLoginID"].string, ownerName: json["OwnerName"].string, paymentTypeCode: json["PaymentTypeCode"].string, receiptImageID: json["ReceiptImageID"].string, transactionAmount: json["TransactionAmount"].double, transactionDate: json["TransactionDate"].string, uri: json["URI"].string, vendorDescription: json["VendorDescription"].string)
   }
   
 }
 
 public extension ConcurClient {
   
-  public func getAllQuickExpense(options: [String : AnyObject?], callback: (error: String!, expenses: [QuickExpense]!, nextPage: String!) -> Void) {
+  public func quickExpensesGet(options: [String : AnyObject?], callback: (error: String!, returnValue: AnyObject!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
+      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)
-        if let error = jsonObject["Message"].string {
-          callback(error: error, expenses: nil, nextPage: nil)
+        if let error = jsonObject["Error"]["Message"].string {
+          callback(error: error, returnValue: nil)
+        } else if let error = jsonObject["Message"].string {
+          callback(error: error, returnValue: nil)
         } else {
-          var expenses: [QuickExpense] = []
-          for (index: String, subJson: JSON) in jsonObject["Items"] {
-            var expense = QuickExpense(json: subJson)
-            expenses.append(expense)
+          if jsonObject["Items"] != nil {
+            var expenses: [QuickExpense] = []
+            for (index: String, subJson: JSON) in jsonObject["Items"] {
+              var expense = QuickExpense(json: subJson)
+              expenses.append(expense)
+            }
+            callback(error: nil, returnValue: expenses)
+          } else {
+            var expense = QuickExpense(json: jsonObject)
+            callback(error: nil, returnValue: expense)
           }
-          callback(error: nil, expenses: expenses, nextPage: jsonObject["NextPage"].string)
         }
       }
     } else {
-      callback(error: "Access Token Missing", expenses: nil, nextPage: nil)
+      callback(error: "Access Token Missing", returnValue: nil)
     }
   }
   
-  public func getQuickExpenseById(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
+  public func quickExpensesPost(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
-      Alamofire.request(request).responseJSON { (req, res, json, error) in
-        var jsonObject = JSON(json!)
-        if let error = jsonObject["Message"].string {
-          callback(error: error, expense: nil)
-        } else {
-          var expense = QuickExpense(json: jsonObject)
-          callback(error: nil, expense: expense)
-        }
-      }
-    } else {
-      callback(error: "Access Token Missing", expense: nil)
-    }
-  }
-  
-  public func createQuickExpense(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
-    if self.AccessToken != nil {
-      let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
+      let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         let jsonObject = JSON(json!)
-        if let error = jsonObject["Message"].string {
+        if let error = jsonObject["Error"]["Message"].string {
           callback(error: error, expense: nil)
         } else {
           var expense = QuickExpense(json: jsonObject)
@@ -97,13 +89,13 @@ public extension ConcurClient {
     }
   }
   
-  public func updateQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
+  public func quickExpensesPut(options: [String : AnyObject?], callback: (error: String!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.putHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
+      let request = ConcurClient.putHTTPRequest("/api/v3.0/expense/quickexpenses", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)
-          if let error = jsonObject["Message"].string {
+          if let error = jsonObject["Error"]["Message"].string {
             callback(error: error)
           } else {
             callback(error: nil)
@@ -115,13 +107,13 @@ public extension ConcurClient {
     }
   }
   
-  public func deleteQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
+  public func quickExpensesDelete(options: [String : AnyObject?], callback: (error: String!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.deleteHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
+      let request = ConcurClient.deleteHTTPRequest("/api/v3.0/expense/quickexpenses", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)
-          if let error = jsonObject["Message"].string {
+          if let error = jsonObject["Error"]["Message"].string {
             callback(error: error)
           } else {
             callback(error: nil)

--- a/Source/QuickExpenses.swift
+++ b/Source/QuickExpenses.swift
@@ -44,7 +44,7 @@ public extension ConcurClient {
   
   public func getAllQuickExpense(options: [String : AnyObject?], callback: (error: String!, expenses: [QuickExpense]!, nextPage: String!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
+      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
@@ -65,7 +65,7 @@ public extension ConcurClient {
   
   public func getQuickExpenseById(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
+      let request = ConcurClient.getHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         var jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
@@ -82,7 +82,7 @@ public extension ConcurClient {
   
   public func createQuickExpense(options: [String : AnyObject?], callback: (error: String!, expense: QuickExpense!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
+      let request = ConcurClient.postHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         let jsonObject = JSON(json!)
         if let error = jsonObject["Message"].string {
@@ -99,7 +99,7 @@ public extension ConcurClient {
   
   public func updateQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.putHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
+      let request = ConcurClient.putHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)
@@ -117,7 +117,7 @@ public extension ConcurClient {
   
   public func deleteQuickExpenseById(options: [String : AnyObject?], callback: (error: String!) -> Void) {
     if self.AccessToken != nil {
-      let request = ConcurClient.deleteHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options)
+      let request = ConcurClient.deleteHTTPRequest("/api/v3.0/expense/quickexpenses/", options: options, authString: self.getAuthString())
       Alamofire.request(request).responseJSON { (req, res, json, error) in
         if json != nil {
           let jsonObject = JSON(json!)

--- a/Source/Utilities.swift
+++ b/Source/Utilities.swift
@@ -5,9 +5,9 @@ public extension ConcurClient {
   internal static var instanceUrl = "https://www.concursolutions.com"
   
   internal class func getHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
-    let urlString = self.instanceUrl.stringByAppendingString(endpoint)
+    var urlString = self.instanceUrl.stringByAppendingString(endpoint)
     if let id = options["id"] as? String {
-      urlString.stringByAppendingString(id)
+      urlString = urlString.stringByAppendingString("/").stringByAppendingString(id)
     }
     if let url = NSURL(string: urlString) {
       let request = NSMutableURLRequest(URL: url)
@@ -68,7 +68,7 @@ public extension ConcurClient {
   
   internal class func putHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     if let id = options["id"] as? String {
-      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString(id)) {
+      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString("/").stringByAppendingString(id)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "PUT"
         if let body = options["Body"] as? NSMutableDictionary {
@@ -101,7 +101,7 @@ public extension ConcurClient {
   
   internal class func deleteHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     if let id = options["id"] as? String {
-      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
+      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString("/").stringByAppendingString(id)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "DELETE"
         if let body = options["Body"] as? NSMutableDictionary {
@@ -132,14 +132,6 @@ public extension ConcurClient {
     }
   }
   
-  private class func addHeaders() -> [String : String] {
-    return [
-      "Accept" : "application/json",
-      "User-Agent" : "SwiftyConcur",
-      "Content-Type" : "application/json"
-    ]
-  }
-  
   internal class func base64Encode(toEncode: String) -> String {
     let utf8Encoded = toEncode.dataUsingEncoding(NSUTF8StringEncoding)
     let base64Encoded = utf8Encoded?.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.allZeros)
@@ -152,6 +144,14 @@ public extension ConcurClient {
     } else {
       return nil
     }
+  }
+  
+  private class func addHeaders() -> [String : String] {
+    return [
+      "Accept" : "application/json",
+      "User-Agent" : "SwiftyConcur",
+      "Content-Type" : "application/json"
+    ]
   }
   
 }

--- a/Source/Utilities.swift
+++ b/Source/Utilities.swift
@@ -1,10 +1,10 @@
 import Alamofire
 
 public extension ConcurClient {
-    
+  
   internal static var instanceUrl = "https://www.concursolutions.com"
   
-  internal class func getHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+  internal class func getHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     let urlString = self.instanceUrl.stringByAppendingString(endpoint)
     if let id = options["id"] as? String {
       urlString.stringByAppendingString(id)
@@ -12,10 +12,12 @@ public extension ConcurClient {
     if let url = NSURL(string: urlString) {
       let request = NSMutableURLRequest(URL: url)
       request.HTTPMethod = "GET"
-      if let body = options["body"] as? NSData {
-        request.HTTPBody = body
+      if let body = options["Body"] as? NSMutableDictionary {
+        var error: NSError?
+        var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
+        request.HTTPBody = bodyData
       }
-      if let headers = options["headers"] as? [String : String] {
+      if let headers = options["Headers"] as? [String : String] {
         for (header, value) in headers {
           request.setValue(value, forHTTPHeaderField: header)
         }
@@ -23,7 +25,10 @@ public extension ConcurClient {
       for (header, value) in self.addHeaders() {
         request.setValue(value, forHTTPHeaderField: header)
       }
-      if let parameters = options["parameters"] as? [String : String] {
+      if authString != nil {
+        request.setValue(authString, forHTTPHeaderField: "Authorization")
+      }
+      if let parameters = options["Parameters"] as? [String : String] {
         Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
       }
       return request
@@ -32,14 +37,16 @@ public extension ConcurClient {
     }
   }
   
-  internal class func postHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+  internal class func postHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
       let request = NSMutableURLRequest(URL: url)
       request.HTTPMethod = "POST"
-      if let body = options["body"] as? NSData {
-        request.HTTPBody = body
+      if let body = options["Body"] as? NSMutableDictionary {
+        var error: NSError?
+        var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
+        request.HTTPBody = bodyData
       }
-      if let headers = options["headers"] as? [String : String] {
+      if let headers = options["Headers"] as? [String : String] {
         for (header, value) in headers {
           request.setValue(value, forHTTPHeaderField: header)
         }
@@ -47,7 +54,10 @@ public extension ConcurClient {
       for (header, value) in self.addHeaders() {
         request.setValue(value, forHTTPHeaderField: header)
       }
-      if let parameters = options["parameters"] as? [String : String] {
+      if authString != nil {
+        request.setValue(authString, forHTTPHeaderField: "Authorization")
+      }
+      if let parameters = options["Parameters"] as? [String : String] {
         Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
       }
       return request
@@ -56,15 +66,17 @@ public extension ConcurClient {
     }
   }
   
-  internal class func putHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+  internal class func putHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     if let id = options["id"] as? String {
       if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString(id)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "PUT"
-        if let body = options["body"] as? NSData {
-          request.HTTPBody = body
+        if let body = options["Body"] as? NSMutableDictionary {
+          var error: NSError?
+          var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
+          request.HTTPBody = bodyData
         }
-        if let headers = options["headers"] as? [String : String] {
+        if let headers = options["Headers"] as? [String : String] {
           for (header, value) in headers {
             request.setValue(value, forHTTPHeaderField: header)
           }
@@ -72,7 +84,10 @@ public extension ConcurClient {
         for (header, value) in self.addHeaders() {
           request.setValue(value, forHTTPHeaderField: header)
         }
-        if let parameters = options["parameters"] as? [String : String] {
+        if authString != nil {
+          request.setValue(authString, forHTTPHeaderField: "Authorization")
+        }
+        if let parameters = options["Parameters"] as? [String : String] {
           Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
         }
         return request
@@ -84,15 +99,17 @@ public extension ConcurClient {
     }
   }
   
-  internal class func deleteHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+  internal class func deleteHTTPRequest(endpoint: String, options: [String : AnyObject?], authString: String!) -> NSURLRequest! {
     if let id = options["id"] as? String {
       if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "DELETE"
-        if let body = options["body"] as? NSData {
-          request.HTTPBody = body
+        if let body = options["Body"] as? NSMutableDictionary {
+          var error: NSError?
+          var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
+          request.HTTPBody = bodyData
         }
-        if let headers = options["headers"] as? [String : String] {
+        if let headers = options["Headers"] as? [String : String] {
           for (header, value) in headers {
             request.setValue(value, forHTTPHeaderField: header)
           }
@@ -100,7 +117,10 @@ public extension ConcurClient {
         for (header, value) in self.addHeaders() {
           request.setValue(value, forHTTPHeaderField: header)
         }
-        if let parameters = options["parameters"] as? [String : String] {
+        if authString != nil {
+          request.setValue(authString, forHTTPHeaderField: "Authorization")
+        }
+        if let parameters = options["Parameters"] as? [String : String] {
           Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
         }
         return request
@@ -141,5 +161,5 @@ internal extension Double {
   internal func toString() -> String {
     return String(format: "%.3f", self)
   }
-
+  
 }

--- a/Source/Utilities.swift
+++ b/Source/Utilities.swift
@@ -1,30 +1,137 @@
-internal class Utilities {
+import Alamofire
+
+public extension ConcurClient {
+    
+  internal static var instanceUrl = "https://www.concursolutions.com"
   
-  private static var baseUrl = "https://www.concursolutions.com"
-  
-  internal class func createHTTPRequest(apiEndpoint: String, headers: [String : String], method: String, body: NSData!) -> NSURLRequest {
-    let url = NSURL(string: self.baseUrl.stringByAppendingString(apiEndpoint))
-    let mutableURLRequest = NSMutableURLRequest(URL: url!)
-    mutableURLRequest.HTTPMethod = method
-    for (header, value) in headers {
-      mutableURLRequest.setValue(value, forHTTPHeaderField: header)
+  internal class func getHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+    let urlString = self.instanceUrl.stringByAppendingString(endpoint)
+    if let id = options["id"] as? String {
+      urlString.stringByAppendingString(id)
     }
-    mutableURLRequest.HTTPBody = body
-    return mutableURLRequest
+    if let url = NSURL(string: urlString) {
+      let request = NSMutableURLRequest(URL: url)
+      request.HTTPMethod = "GET"
+      if let body = options["body"] as? NSData {
+        request.HTTPBody = body
+      }
+      if let headers = options["headers"] as? [String : String] {
+        for (header, value) in headers {
+          request.setValue(value, forHTTPHeaderField: header)
+        }
+      }
+      for (header, value) in self.addHeaders() {
+        request.setValue(value, forHTTPHeaderField: header)
+      }
+      if let parameters = options["parameters"] as? [String : String] {
+        Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+      }
+      return request
+    } else {
+      return nil
+    }
   }
   
-  internal class func buildHeaders(extraHeaders: [String : String]) -> [String : String] {
-    var headers = [
+  internal class func postHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+    if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
+      let request = NSMutableURLRequest(URL: url)
+      request.HTTPMethod = "POST"
+      if let body = options["body"] as? NSData {
+        request.HTTPBody = body
+      }
+      if let headers = options["headers"] as? [String : String] {
+        for (header, value) in headers {
+          request.setValue(value, forHTTPHeaderField: header)
+        }
+      }
+      for (header, value) in self.addHeaders() {
+        request.setValue(value, forHTTPHeaderField: header)
+      }
+      if let parameters = options["parameters"] as? [String : String] {
+        Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+      }
+      return request
+    } else {
+      return nil
+    }
+  }
+  
+  internal class func putHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+    if let id = options["id"] as? String {
+      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString(id)) {
+        let request = NSMutableURLRequest(URL: url)
+        request.HTTPMethod = "PUT"
+        if let body = options["body"] as? NSData {
+          request.HTTPBody = body
+        }
+        if let headers = options["headers"] as? [String : String] {
+          for (header, value) in headers {
+            request.setValue(value, forHTTPHeaderField: header)
+          }
+        }
+        for (header, value) in self.addHeaders() {
+          request.setValue(value, forHTTPHeaderField: header)
+        }
+        if let parameters = options["parameters"] as? [String : String] {
+          Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+        }
+        return request
+      } else {
+        return nil
+      }
+    } else {
+      return nil
+    }
+  }
+  
+  internal class func deleteHTTPRequest(endpoint: String, options: [String : AnyObject?]) -> NSURLRequest! {
+    if let id = options["id"] as? String {
+      if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
+        let request = NSMutableURLRequest(URL: url)
+        request.HTTPMethod = "DELETE"
+        if let body = options["body"] as? NSData {
+          request.HTTPBody = body
+        }
+        if let headers = options["headers"] as? [String : String] {
+          for (header, value) in headers {
+            request.setValue(value, forHTTPHeaderField: header)
+          }
+        }
+        for (header, value) in self.addHeaders() {
+          request.setValue(value, forHTTPHeaderField: header)
+        }
+        if let parameters = options["parameters"] as? [String : String] {
+          Alamofire.ParameterEncoding.URL.encode(request, parameters: parameters)
+        }
+        return request
+      } else {
+        return nil
+      }
+    } else {
+      return nil
+    }
+  }
+  
+  private class func addHeaders() -> [String : String] {
+    return [
       "Accept" : "application/json",
       "User-Agent" : "SwiftyConcur",
       "Content-Type" : "application/json"
     ]
-    
-    for (header, value) in extraHeaders {
-      headers[header] = value
+  }
+  
+  internal class func base64Encode(toEncode: String) -> String {
+    let utf8Encoded = toEncode.dataUsingEncoding(NSUTF8StringEncoding)
+    let base64Encoded = utf8Encoded?.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.allZeros)
+    return base64Encoded!
+  }
+  
+  internal func getAuthString() -> String! {
+    if self.AccessToken != nil {
+      return "OAuth ".stringByAppendingString(self.AccessToken.Token)
+    } else {
+      return nil
     }
-    
-    return headers
   }
   
 }
@@ -34,5 +141,5 @@ internal extension Double {
   internal func toString() -> String {
     return String(format: "%.3f", self)
   }
-  
+
 }

--- a/SwiftyConcur.xcworkspace/contents.xcworkspacedata
+++ b/SwiftyConcur.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,12 @@
       location = "container:"
       name = "Source">
       <FileRef
+         location = "group:Source/ConcurAccessToken.swift">
+      </FileRef>
+      <FileRef
+         location = "group:Source/NativeFlow.swift">
+      </FileRef>
+      <FileRef
          location = "group:Source/QuickExpenses.swift">
       </FileRef>
       <FileRef

--- a/SwiftyConcuriOSExample/SwiftyConcuriOSExample/ViewController.swift
+++ b/SwiftyConcuriOSExample/SwiftyConcuriOSExample/ViewController.swift
@@ -7,8 +7,8 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     // Example of getting access token
-    var client = ConcurClient(consumerKey: "CONSUMER KEY", consumerSecret: "CONSUMER SECRET")
-    client.getNativeFlowAccessToken("EMAIL", password: "PASSWORD", callback: { (error, token) in
+    var client = ConcurClient(consumerKey: "", consumerSecret: "")
+    client.getNativeFlowAccessToken("", password: "", callback: { (error, token) in
       if error != nil {
         println(error)
       } else {
@@ -19,17 +19,18 @@ class ViewController: UIViewController {
         // Example of building the body for a POST request to Quick Expenses
         var expense = NSMutableDictionary()
         expense.setValue("USD", forKey: "CurrencyCode")
-        expense.setValue("TransactionAmount", forKey: "456.78")
-        expense.setValue("TransactionDate", forKey: "2015-07-12")
+        expense.setValue("123.45", forKey: "TransactionAmount")
+        expense.setValue("2015-07-12", forKey: "TransactionDate")
         var options : [String : AnyObject?] = [
-          "body" : expense
+          "Body" : expense
         ]
         
         // Example of creating a Quick Expense and receiving the ID and URI back in the callback
-        client.createQuickExpense(options, callback: { (error, expense) in
+        client.quickExpensesPost(options, callback: { (error, expense) in
           if error != nil {
             println(error)
           } else {
+            println(expense)
             println(expense.ID)
             println(expense.URI)
           }

--- a/SwiftyConcuriOSExample/SwiftyConcuriOSExample/ViewController.swift
+++ b/SwiftyConcuriOSExample/SwiftyConcuriOSExample/ViewController.swift
@@ -6,7 +6,36 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    
+    // Example of getting access token
+    var client = ConcurClient(consumerKey: "CONSUMER KEY", consumerSecret: "CONSUMER SECRET")
+    client.getNativeFlowAccessToken("EMAIL", password: "PASSWORD", callback: { (error, token) in
+      if error != nil {
+        println(error)
+      } else {
+        
+        // Example of creating client with access token
+        client = ConcurClient(accessToken: token)
+        
+        // Example of building the body for a POST request to Quick Expenses
+        var expense = NSMutableDictionary()
+        expense.setValue("USD", forKey: "CurrencyCode")
+        expense.setValue("TransactionAmount", forKey: "456.78")
+        expense.setValue("TransactionDate", forKey: "2015-07-12")
+        var options : [String : AnyObject?] = [
+          "body" : expense
+        ]
+        
+        // Example of creating a Quick Expense and receiving the ID and URI back in the callback
+        client.createQuickExpense(options, callback: { (error, expense) in
+          if error != nil {
+            println(error)
+          } else {
+            println(expense.ID)
+            println(expense.URI)
+          }
+        })
+      }
+    })
   }
 
   override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Here's a list of what I changed

- 4 different utility functions for each type of HTTP request
- Quick Expense object can only be created internally by Concur client after calling a request, values are read only
- Native flow authentication in separate file
- Access Token is separate object
- Get request for Quick Expense (and future endpoints) does not have separate functions for get all & get by ID. Instead, the utility function will look for the ID in the options and if it sees it, it will append to the end of the URL. Then in the quickExpensesGet function, it searches for the "Items" key in the JSON response and if it doesn't find it, it just returns one object.
- Post request returns Quick Expense object with ID & URI values filled in