### PR TITLE
New way to create Body content for POST requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,12 @@ Once the client is initialized, making requests can be made to the API. An examp
 
 ```
 // QuickExpenses POST
-var expense = NSMutableDictionary()
-expense.setValue("USD", forKey: "CurrencyCode")
-expense.setValue("20.15", forKey: "TransactionAmount")
-expense.setValue("2015-06-19", forKey: "TransactionDate")
-expense.setValue("Concur Business", forKey: "VendorDescription")
 var options : [String : AnyObject?] = [
-  "Body" : expense
+  "Body" : [
+    "CurrencyCode" : "USD",
+    "TransactionAmount" : "20.15",
+    "TransactionDate" : "2015-06-19"
+  ]
 ]
 client.quickExpensesPost(options, callback: { (error, returnValue) in
   let expense = returnValue as! QuickExpense

--- a/Source/Utilities.swift
+++ b/Source/Utilities.swift
@@ -13,7 +13,7 @@ public extension ConcurClient {
     if let url = NSURL(string: urlString) {
       let request = NSMutableURLRequest(URL: url)
       request.HTTPMethod = "GET"
-      if let body = options["Body"] as? NSMutableDictionary {
+      if let body = options["Body"] as? [String : String] {
         var error: NSError?
         var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
         request.HTTPBody = bodyData
@@ -59,7 +59,7 @@ public extension ConcurClient {
     if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint)) {
       let request = NSMutableURLRequest(URL: url)
       request.HTTPMethod = "POST"
-      if let body = options["Body"] as? NSMutableDictionary {
+      if let body = options["Body"] as? [String : String] {
         var error: NSError?
         var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
         request.HTTPBody = bodyData
@@ -89,7 +89,7 @@ public extension ConcurClient {
       if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString("/").stringByAppendingString(id)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "PUT"
-        if let body = options["Body"] as? NSMutableDictionary {
+        if let body = options["Body"] as? [String : String] {
           var error: NSError?
           var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
           request.HTTPBody = bodyData
@@ -122,7 +122,7 @@ public extension ConcurClient {
       if let url = NSURL(string: self.instanceUrl.stringByAppendingString(endpoint).stringByAppendingString("/").stringByAppendingString(id)) {
         let request = NSMutableURLRequest(URL: url)
         request.HTTPMethod = "DELETE"
-        if let body = options["Body"] as? NSMutableDictionary {
+        if let body = options["Body"] as? [String : String] {
           var error: NSError?
           var bodyData = NSJSONSerialization.dataWithJSONObject(body, options: NSJSONWritingOptions.allZeros, error: &error)
           request.HTTPBody = bodyData


### PR DESCRIPTION
Instead of: 

```
var expense = NSMutableDictionary()
    expense.setValue("USD", forKey: "CurrencyCode")
    expense.setValue("20.15", forKey: "TransactionAmount")
    expense.setValue("2015-06-19", forKey: "TransactionDate")
    expense.setValue("Concur Business", forKey: "VendorDescription")
    var options : [String : AnyObject?] = [
      "Body" : expense
    ]
    client.quickExpensesPost(options, callback: { (error, returnValue) in
      let expenses: ConcurCollection<ConnectionRequest> = returnValue as! ConcurCollection<ConnectionRequest>
```

We now do:

```
var options : [String : AnyObject?] = [
      "Body" : [
        "CurrencyCode" : "USD",
        "TransactionAmount" : "20.15",
        "TransactionDate" : "2015-06-19"
      ]
    ]
    
    client.quickExpensesPost(options, callback: { (error, returnValue) in
      let expenses: ConcurCollection<ConnectionRequest> = returnValue as! ConcurCollection<ConnectionRequest>
```